### PR TITLE
🐛 Fixed reloading paths

### DIFF
--- a/src/layouts/common.astro
+++ b/src/layouts/common.astro
@@ -71,6 +71,9 @@ const navigation = await getNavigationLinks(currentLocale);
           targetLocale: language,
         });
 
+        console.log('currentPath:', currentPath);
+        console.log('localePath:', localePath);
+
         // redirect user to the correct language (if needed)
         if (localePath !== currentPath) {
           window.location.href = localePath;

--- a/src/layouts/common.astro
+++ b/src/layouts/common.astro
@@ -64,12 +64,21 @@ const navigation = await getNavigationLinks(currentLocale);
         const { segments, currentLocale } = getSegments(currentPath);
 
         // get localized path (current one)
-        const localePath = await getLocalizedPath({
+        let localePath = await getLocalizedPath({
           currentLocale,
           currentPath,
           segments,
           targetLocale: language,
         });
+
+        // there might be a trailing slash in the URL - unify it (if currentPath has one, add it to localePath)
+        if (currentPath.endsWith('/') && !localePath.endsWith('/')) {
+          localePath += '/';
+        }
+
+        if (localePath.endsWith('/') && !currentPath.endsWith('/')) {
+          localePath = localePath.slice(0, -1);
+        }
 
         console.log('currentPath:', currentPath);
         console.log('localePath:', localePath);

--- a/src/layouts/common.astro
+++ b/src/layouts/common.astro
@@ -76,12 +76,10 @@ const navigation = await getNavigationLinks(currentLocale);
           localePath += '/';
         }
 
+        // also, if localePath has a trailing slash, but currentPath doesn't, remove it
         if (localePath.endsWith('/') && !currentPath.endsWith('/')) {
           localePath = localePath.slice(0, -1);
         }
-
-        console.log('currentPath:', currentPath);
-        console.log('localePath:', localePath);
 
         // redirect user to the correct language (if needed)
         if (localePath !== currentPath) {

--- a/src/lib/utils/navigation.ts
+++ b/src/lib/utils/navigation.ts
@@ -81,7 +81,9 @@ export const getLocalizedPath = async ({
     defaultRoutes = await getRouteTranslations(defaultLocale);
   }
 
-  const pathSegments = segments.slice(currentLocale === defaultLocale ? 0 : 1);
+  const pathSegments = segments
+    .filter(Boolean)
+    .slice(currentLocale === defaultLocale ? 0 : 1);
 
   if (currentLocale !== targetLocale) {
     pathSegments.forEach((segment, index) => {


### PR DESCRIPTION
There was a problem with checking routes.

If `currentPath` and `localePath` in `common.astro` layout are different, it redirects user to the locale one. The problem was in a situation, when the localized path or the current path have or have not a trailing slash - this resulted in constant reloading of the page because of a difference like `SITE/page` vs `SITE/page/`. 

Added some conditional logic in there to prevent those situations.